### PR TITLE
Fix dynamic chapter counts in navigation

### DIFF
--- a/src/components/navigation/BibleNavigation.jsx
+++ b/src/components/navigation/BibleNavigation.jsx
@@ -37,6 +37,8 @@ const BibleNavigation = () => {
     isLoading,
     setCurrentBook,
     setCurrentChapter,
+    chapterOptions,
+    getChapterCount,
   } = useBible();
   
   const [showDropdown, setShowDropdown] = useState(false);
@@ -68,11 +70,10 @@ const BibleNavigation = () => {
     return <LoadingState />;
   }
 
-  // Get number of chapters for current book
-  const chapters = Array.from(
-    { length: 50 }, // Default to 50 chapters as maximum
-    (_, i) => i + 1
-  );
+  // Get number of chapters for the current book using data from context
+  const chapters = chapterOptions.length > 0
+    ? chapterOptions
+    : Array.from({ length: getChapterCount(currentBook) }, (_, i) => i + 1);
 
   return (
     <div className="relative inline-block" ref={dropdownRef}>


### PR DESCRIPTION
## Summary
- use chapter data from `BibleContext` when rendering chapter dropdown

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684499a30e688330b81cff40430bb626