### PR TITLE
Fix README dev command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In the frontend directory, you can run:
 
 #### `npm run dev`
 
-Runs the app in development mode using React Scripts.\
+Runs the app in development mode using React Scripts.
 Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 
 #### `npm start`


### PR DESCRIPTION
## Summary
- fix the `npm run dev` description in the README

## Testing
- `

------
https://chatgpt.com/codex/tasks/task_e_68449be919d0833086186be2d33570ff